### PR TITLE
Suggestion: Polykinded On + OnTarget class

### DIFF
--- a/derivingvia-extras.cabal
+++ b/derivingvia-extras.cabal
@@ -37,6 +37,7 @@ source-repository head
 library
     exposed-modules:
         Deriving.On
+        Deriving.On.Class
         Deriving.On.Nth
     hs-source-dirs: src
     default-language: Haskell98

--- a/derivingvia-extras.cabal
+++ b/derivingvia-extras.cabal
@@ -37,6 +37,7 @@ source-repository head
 library
     exposed-modules:
         Deriving.On
+        Deriving.On.Nth
     hs-source-dirs: src
     default-language: Haskell98
     build-depends:

--- a/src/Deriving/On.hs
+++ b/src/Deriving/On.hs
@@ -1,5 +1,6 @@
 {-# Language DataKinds                #-}
 {-# Language InstanceSigs             #-}
+{-# Language PolyKinds                #-}
 {-# Language ScopedTypeVariables      #-}
 {-# Language StandaloneKindSignatures #-}
 {-# Language TypeApplications         #-}
@@ -50,17 +51,17 @@ import GHC.TypeLits  (Symbol)
 -- >> hash alice == hash bob
 -- True
 -- @
-type    On :: Type -> Symbol -> Type
+type    On :: forall k. Type -> k -> Type
 newtype a `On` field = On a
 
-instance (HasField field a b, Eq b) => Eq (a `On` field) where
+instance (HasField field a b, Eq b) => Eq (On @Symbol a field) where
   (==) :: a `On` field -> a `On` field -> Bool
   On a1 == On a2 = ((==) `on` getField @field) a1 a2
 
-instance (HasField field a b, Ord b) => Ord (a `On` field) where
+instance (HasField field a b, Ord b) => Ord (On @Symbol a field) where
   compare :: a `On` field -> a `On` field -> Ordering
   On a1 `compare` On a2 = comparing (getField @field) a1 a2
 
-instance (HasField field a b, Hashable b) => Hashable (a `On` field) where
+instance (HasField field a b, Hashable b) => Hashable (On @Symbol a field) where
   hashWithSalt :: Int -> a `On` field -> Int
   hashWithSalt salt (On a) = hashWithSalt salt (getField @field a)

--- a/src/Deriving/On.hs
+++ b/src/Deriving/On.hs
@@ -9,12 +9,11 @@
 
 module Deriving.On (On(..)) where
 
-import Data.Function (on)
-import Data.Hashable (Hashable(..))
-import Data.Kind     (Type)
-import Data.Ord      (comparing)
-import GHC.Records   (HasField(..))
-import GHC.TypeLits  (Symbol)
+import Data.Function     (on)
+import Data.Hashable     (Hashable(..))
+import Data.Kind         (Type)
+import Data.Ord          (comparing)
+import Deriving.On.Class (OnTarget (..))
 
 -- | With 'DerivingVia': to derive non-structural instances. Specifies
 -- what field to base instances on.
@@ -54,14 +53,15 @@ import GHC.TypeLits  (Symbol)
 type    On :: forall k. Type -> k -> Type
 newtype a `On` field = On a
 
-instance (HasField field a b, Eq b) => Eq (On @Symbol a field) where
+instance (OnTarget k target a b, Eq b) => Eq (On @k a target) where
   (==) :: a `On` field -> a `On` field -> Bool
-  On a1 == On a2 = ((==) `on` getField @field) a1 a2
+  On a1 == On a2 = ((==) `on` getTarget @k @target) a1 a2
 
-instance (HasField field a b, Ord b) => Ord (On @Symbol a field) where
-  compare :: a `On` field -> a `On` field -> Ordering
-  On a1 `compare` On a2 = comparing (getField @field) a1 a2
 
-instance (HasField field a b, Hashable b) => Hashable (On @Symbol a field) where
-  hashWithSalt :: Int -> a `On` field -> Int
-  hashWithSalt salt (On a) = hashWithSalt salt (getField @field a)
+instance (OnTarget k target a b, Ord b) => Ord (On @k a target) where
+  compare :: a `On` target -> a `On` target -> Ordering
+  On a1 `compare` On a2 = comparing (getTarget @k @target) a1 a2
+
+instance (OnTarget k target a b, Hashable b) => Hashable (On @k a target) where
+  hashWithSalt :: Int -> a `On` target -> Int
+  hashWithSalt salt (On a) = hashWithSalt salt (getTarget @k @target a)

--- a/src/Deriving/On/Class.hs
+++ b/src/Deriving/On/Class.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE AllowAmbiguousTypes    #-}
+{-# LANGUAGE DataKinds              #-}
+{-# LANGUAGE FlexibleContexts       #-}
 {-# LANGUAGE FlexibleInstances      #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE KindSignatures         #-}
@@ -12,9 +14,16 @@ module Deriving.On.Class where
 
 import GHC.Records (HasField (getField))
 import GHC.TypeLits (Symbol)
+import Data.Kind (Type)
 
 class OnTarget k (target :: k) a b | k target a -> b where
   getTarget :: a -> b
 
 instance HasField field a b => OnTarget Symbol field a b where
   getTarget = getField @field
+
+instance (OnTarget Type t a b, OnTarget Type u a c) => OnTarget Type (t, u) a (b, c) where
+  getTarget a = (getTarget @_ @t a, getTarget @_ @u a)
+
+instance (OnTarget k t a b, OnTarget l u a c) => OnTarget (k, l) '(t, u) a (b, c) where
+  getTarget a = (getTarget @k @t a, getTarget @l @u a)

--- a/src/Deriving/On/Class.hs
+++ b/src/Deriving/On/Class.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE AllowAmbiguousTypes    #-}
+{-# LANGUAGE FlexibleInstances      #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE KindSignatures         #-}
+{-# LANGUAGE MultiParamTypeClasses  #-}
+{-# LANGUAGE PolyKinds              #-}
+{-# LANGUAGE ScopedTypeVariables    #-}
+{-# LANGUAGE TypeApplications       #-}
+{-# LANGUAGE UndecidableInstances   #-}
+
+module Deriving.On.Class where
+
+import GHC.Records (HasField (getField))
+import GHC.TypeLits (Symbol)
+
+class OnTarget k (target :: k) a b | k target a -> b where
+  getTarget :: a -> b
+
+instance HasField field a b => OnTarget Symbol field a b where
+  getTarget = getField @field

--- a/src/Deriving/On/Nth.hs
+++ b/src/Deriving/On/Nth.hs
@@ -1,0 +1,141 @@
+{-# LANGUAGE AllowAmbiguousTypes      #-}
+{-# LANGUAGE ConstraintKinds          #-}
+{-# LANGUAGE DataKinds                #-}
+{-# LANGUAGE EmptyDataDecls           #-}
+{-# LANGUAGE FlexibleContexts         #-}
+{-# LANGUAGE FlexibleInstances        #-}
+{-# LANGUAGE FunctionalDependencies   #-}
+{-# LANGUAGE InstanceSigs             #-}
+{-# LANGUAGE KindSignatures           #-}
+{-# LANGUAGE MultiParamTypeClasses    #-}
+{-# LANGUAGE PolyKinds                #-}
+{-# LANGUAGE ScopedTypeVariables      #-}
+{-# LANGUAGE StandaloneKindSignatures #-}
+{-# LANGUAGE TypeApplications         #-}
+{-# LANGUAGE TypeFamilies             #-}
+{-# LANGUAGE TypeOperators            #-}
+{-# LANGUAGE TypeSynonymInstances     #-}
+{-# LANGUAGE UndecidableInstances     #-}
+
+module Deriving.On.Nth where
+
+import Data.Function (on)
+import Data.Hashable (Hashable (..))
+import Data.Kind     (Constraint, Type)
+import Data.Ord      (comparing)
+import Deriving.On   (On (..))
+import qualified GHC.Generics as G
+import GHC.TypeLits  (CmpNat, ErrorMessage (..), KnownNat, Nat, TypeError, type (+), type (-), type (<=?))
+
+-- | With 'DerivingVia': to derive non-structural instances with @'On'.
+-- @'Nth' specifies what field to base instances on based on its position in
+-- a product type.
+--
+-- Does not support types with multiple constructors.
+type Nth :: Nat -> Type
+data Nth n
+
+instance (HasNth n a b, Eq b) => Eq (a `On` Nth n) where
+  (==) :: a `On` Nth n -> a `On` Nth n -> Bool
+  On a1 == On a2 = ((==) `on` getNth @n) a1 a2
+
+instance (HasNth n a b, Ord b) => Ord (a `On` Nth n) where
+  compare :: a `On` field -> a `On` field -> Ordering
+  On a1 `compare` On a2 = comparing (getNth @n) a1 a2
+
+instance (HasNth n a b, Hashable b) => Hashable (a `On` Nth n) where
+  hashWithSalt :: Int -> a `On` field -> Int
+  hashWithSalt salt (On a) = hashWithSalt salt (getNth @n a)
+
+-- High-level constraint synonym + helper
+
+type HasNth n a v = (G.Generic a, GHasNth n (G.Rep a) a, v ~ Value n (G.Rep a))
+
+getNth :: forall n a v. HasNth n a v => a -> v
+getNth = gGetNth @n @_ @a . G.from
+
+-- Generically get a value from a product type
+
+class (KnownNat n) => GHasNth n t originalTypeForErrorReporting where
+  type Value n t :: Type
+  gGetNth :: t x -> Value n t
+
+instance (KnownNat n, GHasNth n constructors original) => GHasNth n (G.D1 meta constructors) original where
+  type Value n (G.D1 meta constructors) = Value n constructors
+  gGetNth (G.M1 c) = gGetNth @n @_ @original c
+
+instance
+  ( KnownNat n,
+    v ~ (),
+    TypeError ('Text "Nth does not work on sum types like" ':$$: 'ShowType original)
+  ) =>
+  GHasNth n (l G.:+: r) original
+  where
+  type Value n (l G.:+: r) = TypeError ('Text "Nth does not work on sum types")
+  gGetNth = error "Nth does not work on sum types"
+
+instance
+  ( KnownNat n,
+    CmpNat n (SelectorSize selectors) ~ 'LT,
+    If @Constraint
+      (SelectorSize selectors <=? n)
+      ( TypeError
+          ( 'Text "Specified index Nth " ':<>: 'ShowType n ':<>: 'Text " is too large for type"
+              ':$$: 'ShowType original
+              ':$$: 'ShowType (SelectorSize selectors)
+          )
+      )
+      (),
+    (GHasNth n selectors original)
+  ) =>
+  GHasNth n (G.C1 meta selectors) original
+  where
+  type Value n (G.C1 meta selectors) = Value n selectors
+  gGetNth (G.M1 c) = gGetNth @n @_ @original c
+
+instance
+  (n ~ 0) =>
+  GHasNth n (G.S1 meta (G.K1 metaK v)) original
+  where
+  type Value n (G.S1 meta (G.K1 metaK v)) = v
+  gGetNth (G.M1 (G.K1 v)) = v
+
+instance
+  ( KnownNat n,
+    GetNowOrLater (PositiveNat n) selectorL selectorR original
+  ) =>
+  GHasNth n (selectorL G.:*: selectorR) original
+  where
+  type Value n (selectorL G.:*: selectorR) = SValue (PositiveNat n) selectorL selectorR
+  gGetNth (l G.:*: r) = getNowOrLater @_ @(PositiveNat n) @_ @_ @original l r
+
+type GetNowOrLater :: Maybe Nat -> (k -> Type) -> (k -> Type) -> Type -> Constraint
+class GetNowOrLater positiveN now later originalForErrorReporting where
+  type SValue positiveN now later :: Type
+  getNowOrLater :: now x -> later x -> SValue positiveN now later
+
+instance GetNowOrLater 'Nothing (G.S1 meta (G.K1 metaK v)) later originalForErrorReporting where
+  type SValue 'Nothing (G.S1 meta (G.K1 metaK v)) later = v
+  getNowOrLater (G.M1 (G.K1 x)) _ = x
+
+instance
+  (GHasNth n later originalForErrorReporting) =>
+  GetNowOrLater ('Just n) (G.S1 meta t) later originalForErrorReporting
+  where
+  type SValue ('Just n) (G.S1 meta t) later = Value n later
+  getNowOrLater _ later = gGetNth @n @_ @originalForErrorReporting later
+
+-- Helper type families
+
+type family PositiveNat n :: Maybe Nat where
+  PositiveNat 0 = 'Nothing
+  PositiveNat n = 'Just (n - 1)
+
+type family SelectorSize t :: Nat where
+  SelectorSize (G.S1 _ _) = 1
+  SelectorSize (l G.:*: r) = SelectorSize l + SelectorSize r
+
+type If :: forall k. Bool -> k -> k -> k
+type family If c t e where
+  If 'True t _ = t
+  If 'False _ e = e


### PR DESCRIPTION
This splits functionality on `On` into a typeclass to allow adding new types that implement targets for it. The typeclass dispatches on a kind, so we can still have the general "Symbol implies HasField" behaviour. I then took advantage of that to add:

* and instance for pairs of targets
* an `Nth` type that can be used to index fields by their position, using GHC Generics.

I can see how this may end up overcomplicating the design, but the end result looks nice to me. Any other field accessors will now only need to define a single instance.

I have very little experience with GHC Generics, so I don't know if there's a better way to write the code in `Deriving.On.Nth`.